### PR TITLE
v0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # [v0.9.5]
+## Features
+- [kv package] add MapperMarshaller interface for custom defined data marshaller
 ## Enhance
 - [base] OriginalError use recursion check.
 - [base] Error() format adjust, use "\n" split each fields.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [v0.9.5]
+## Breaking Change
+- [trigger package] replace handler param callback by queue.Buffer for receiving the elements batch pack by trigger.
+---
 # [v0.9.4] 2024-02-09
 ## Enhance
 - [kv package] add supports convert map[string]interface{} to object.
@@ -5,7 +9,6 @@
 # [v0.9.3] 2024-02-02
 ## Features
 - [kv package] convert struct object with tag defined to a map[string]interface{} like json/yaml Marshal do.
----
 # [v0.9.2] 2024-01-26
 ## Features
 - [varfmt package] format string with variable by custom syntax and variable value provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## Enhance
 - [base] OriginalError use recursion check.
 - [base] Error() format adjust, use "\n" split each fields.
+- [kv package] ObjectToStruct map type support empty key
 ## Breaking Change
 - [trigger package] replace handler param callback by queue.Buffer for receiving the elements batch pack by trigger.
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# [v0.9.5]
+# [v0.9.5] 2024-05-24
+## Breaking Change
+- [trigger package] replace handler param callback by queue.Buffer for receiving the elements batch pack by trigger.
 ## Bugs
 - [kv package] fix marshal failed for time.Time, time.Duration type marshal as struct
 ## Features
@@ -7,8 +9,6 @@
 - [base] OriginalError use recursion check.
 - [base] Error() format adjust, use "\n" split each fields.
 - [kv package] ObjectToStruct map type support empty key
-## Breaking Change
-- [trigger package] replace handler param callback by queue.Buffer for receiving the elements batch pack by trigger.
 ---
 # [v0.9.4] 2024-02-09
 ## Enhance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # [v0.9.5]
+## Bugs
+- [kv package] fix marshal failed for time.Time, time.Duration type marshal as struct
 ## Features
 - [kv package] add MapperMarshaller interface for custom defined data marshaller
 ## Enhance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # [v0.9.5]
+## Enhance
+- [base] OriginalError use recursion check.
+- [base] Error() format adjust, use "\n" split each fields.
 ## Breaking Change
 - [trigger package] replace handler param callback by queue.Buffer for receiving the elements batch pack by trigger.
 ---

--- a/error.go
+++ b/error.go
@@ -35,7 +35,7 @@ type Error struct {
 	// Labels defines many labels of the error object, when used in searching scenes.
 	// It will be added when call WithLabel method.
 	// When do formatting, it will be split with ",".
-	Labels []string
+	Labels map[string]struct{}
 
 	// Msg defines additional comment for the error.
 	// It will be added when call WithMessage method.
@@ -146,7 +146,7 @@ func (e *Error) WithMessage(msg string) *Error {
 }
 
 func (e *Error) WithLabel(l string) *Error {
-	e.Labels = append(e.Labels, l)
+	e.Labels[strings.ToLower(l)] = struct{}{}
 	return e
 }
 
@@ -158,7 +158,17 @@ func (e *Error) Error() string {
 		builder.WriteString(fmt.Sprintf(", msg=%s\n", e.Message()))
 	}
 	if len(e.Labels) != 0 {
-		builder.WriteString(fmt.Sprintf("labels=%s\n", strings.Join(e.Labels, ",")))
+		builder.WriteString("labels=")
+		var split bool
+		for l := range e.Labels {
+			if !split {
+				split = true
+			} else {
+				builder.WriteString(",")
+			}
+			builder.WriteString(l)
+		}
+		builder.WriteString("\n")
 	}
 	for k, v := range e.Fields {
 		builder.WriteString(fmt.Sprintf(", %s=%+v\n", k, v))

--- a/error.go
+++ b/error.go
@@ -153,16 +153,18 @@ func (e *Error) WithLabel(l string) *Error {
 // Error defines the standard interface for error
 func (e *Error) Error() string {
 	var builder strings.Builder
-	builder.WriteString(fmt.Sprintf("err=%s", e.Err.Error()))
+	builder.WriteString(fmt.Sprintf("err=%s\n", e.Err.Error()))
 	if len(e.Msg) != 0 {
-		builder.WriteString(fmt.Sprintf(", msg=%s", e.Message()))
+		builder.WriteString(fmt.Sprintf(", msg=%s\n", e.Message()))
 	}
-	builder.WriteString(fmt.Sprintf("labels=%s", strings.Join(e.Labels, ",")))
+	if len(e.Labels) != 0 {
+		builder.WriteString(fmt.Sprintf("labels=%s\n", strings.Join(e.Labels, ",")))
+	}
 	for k, v := range e.Fields {
-		builder.WriteString(fmt.Sprintf(", %s=%+v", k, v))
+		builder.WriteString(fmt.Sprintf(", %s=%+v\n", k, v))
 	}
 	if len(e.Stack) != 0 {
-		builder.WriteString(fmt.Sprintf(", stack:%s", e.Stack))
+		builder.WriteString(fmt.Sprintf(", stack:%s\n", e.Stack))
 	}
 	return builder.String()
 }

--- a/kv/mapper.go
+++ b/kv/mapper.go
@@ -15,6 +15,8 @@ var (
 
 // MapperMarshaller is used for custom defined type for marshal to a general interface{} type,
 // which could be handled by Mapper. It works as the yaml.MarshalYAML interface do.
+// NOTICE: Implement the MapperMarshaller interface with Non-Pointer receiver as usual,
+// or it will not be called when the field pointer could not be used.
 type MapperMarshaller interface {
 	MapperMarshal() interface{}
 }

--- a/kv/mapper.go
+++ b/kv/mapper.go
@@ -1,6 +1,8 @@
 package kv
 
-import "errors"
+import (
+	"errors"
+)
 
 const (
 	ErrTypeUnmarshalInvalidType = "kv.unmarshal_invalid_type"
@@ -10,6 +12,12 @@ var (
 	ErrObjectInvalidType    = errors.New("object to unmarshal is not struct type")
 	ErrUnsupportedFieldType = errors.New("type of field to unmarshal is not supported")
 )
+
+// MapperMarshaller is used for custom defined type for marshal to a general interface{} type,
+// which could be handled by Mapper. It works as the yaml.MarshalYAML interface do.
+type MapperMarshaller interface {
+	MapperMarshal() interface{}
+}
 
 // Mapper helps transform struct object between map[string]interface{} with custom options.
 // It supports nested map, slice, array and struct, syntax is similar as json/yaml tag used by Marshal.

--- a/kv/marshal.go
+++ b/kv/marshal.go
@@ -73,8 +73,10 @@ func (m *Mapper) handleField(ctx *context) {
 	switch v.(type) {
 	case time.Time:
 		m.handleBasic(ctx)
+		return
 	case time.Duration:
 		m.handleBasic(ctx)
+		return
 	default:
 	}
 	switch ctx.value.Type().Kind() {

--- a/kv/marshal.go
+++ b/kv/marshal.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 	"unicode"
 )
 
@@ -58,6 +59,13 @@ func (m *Mapper) handleField(ctx *context) {
 		ctx.meta.t = ctx.value.Type()
 		m.handleField(ctx)
 		return
+	}
+	switch v.(type) {
+	case time.Time:
+		m.handleBasic(ctx)
+	case time.Duration:
+		m.handleBasic(ctx)
+	default:
 	}
 	switch ctx.value.Type().Kind() {
 	case reflect.Struct:

--- a/kv/marshal.go
+++ b/kv/marshal.go
@@ -50,6 +50,15 @@ func (m *Mapper) handleField(ctx *context) {
 		ctx.value = ctx.value.Elem()
 		t = ctx.value.Type().Kind()
 	}
+	v := ctx.value.Interface()
+	marshaller, ok := v.(MapperMarshaller)
+	if ok {
+		v := marshaller.MapperMarshal()
+		ctx.value = reflect.ValueOf(v)
+		ctx.meta.t = ctx.value.Type()
+		m.handleField(ctx)
+		return
+	}
 	switch ctx.value.Type().Kind() {
 	case reflect.Struct:
 		m.handleStruct(ctx)

--- a/kv/marshal.go
+++ b/kv/marshal.go
@@ -51,15 +51,25 @@ func (m *Mapper) handleField(ctx *context) {
 		ctx.value = ctx.value.Elem()
 		t = ctx.value.Type().Kind()
 	}
-	v := ctx.value.Interface()
-	marshaller, ok := v.(MapperMarshaller)
+
+	var (
+		v          = ctx.value.Interface()
+		marshaller MapperMarshaller
+		ok         bool
+	)
+	if ctx.value.CanAddr() {
+		marshaller, ok = ctx.value.Addr().Interface().(MapperMarshaller)
+	}
+	if !ok {
+		marshaller, ok = v.(MapperMarshaller)
+	}
 	if ok {
-		v := marshaller.MapperMarshal()
-		ctx.value = reflect.ValueOf(v)
+		ctx.value = reflect.ValueOf(marshaller.MapperMarshal())
 		ctx.meta.t = ctx.value.Type()
 		m.handleField(ctx)
 		return
 	}
+
 	switch v.(type) {
 	case time.Time:
 		m.handleBasic(ctx)

--- a/kv/marshal.go
+++ b/kv/marshal.go
@@ -113,11 +113,15 @@ func (m *Mapper) handleStruct(ctx *context) {
 func (m *Mapper) handleMap(ctx *context) {
 	for _, key := range ctx.value.MapKeys() {
 		v := ctx.value.MapIndex(key)
+		k := ctx.meta.key
+		if key.String() != "" {
+			k += m.nestConcat + key.String()
+		}
 		m.handleField(&context{
 			kv: ctx.kv,
 			meta: &fieldMeta{
 				t:         v.Type(),
-				key:       ctx.meta.key + m.nestConcat + key.String(),
+				key:       k,
 				omitempty: false,
 			},
 			value: v,

--- a/kv/marshal_test.go
+++ b/kv/marshal_test.go
@@ -146,6 +146,41 @@ func TestMarshalMap(t *testing.T) {
 	})
 }
 
+type ObjectMarshalInt struct {
+	N int                `kv:"n"`
+	F ObjectMarshalFloat `kv:"float"`
+}
+
+type ObjectMarshalFloat struct {
+	F float64 `kv:"f"`
+}
+
+func (this *ObjectMarshalFloat) MapperMarshal() interface{} {
+	return this.F
+}
+
+func TestMarshaller(t *testing.T) {
+	type Object struct {
+		Int ObjectMarshalInt `kv:"int"`
+		S   string           `kv:"s"`
+	}
+	mapper := NewMapper()
+	m := mapper.ObjectToMap(&Object{
+		Int: ObjectMarshalInt{
+			N: 99,
+			F: ObjectMarshalFloat{
+				F: 66.66,
+			},
+		},
+		S: "88",
+	})
+	assertMap(t, m, map[string]interface{}{
+		"s":           "88",
+		"int_n":       99,
+		"int_float_f": 66.66,
+	})
+}
+
 func TestSplitWords(t *testing.T) {
 	valueExpected := map[string][]string{
 		"FirstDay":     {"First", "Day"},

--- a/kv/marshal_test.go
+++ b/kv/marshal_test.go
@@ -2,6 +2,7 @@ package kv
 
 import (
 	"testing"
+	"time"
 )
 
 func TestMarshalNilPointer(t *testing.T) {
@@ -146,6 +147,18 @@ func TestMarshalMap(t *testing.T) {
 	})
 }
 
+type ObjectMarshalMap struct {
+	t time.Time
+}
+
+func (o ObjectMarshalMap) MapperMarshal() interface{} {
+	return map[string]interface{}{
+		"time_string": o.t.String(),
+		"time_unix":   o.t.Unix(),
+		"time_date":   o.t.Format("2006-01-02"),
+	}
+}
+
 type ObjectMarshalFloat struct {
 	f float64
 }
@@ -162,7 +175,12 @@ func TestMarshaller(t *testing.T) {
 		Float            ObjectMarshalFloat `kv:"float"`
 		NestFloat        NestObject         `kv:"nest"`
 		PointerNestFloat *NestObject        `kv:"p_nest"`
+		Map              ObjectMarshalMap   `kv:"map"`
 	}
+	tm := time.Date(2024, 5, 20, 17, 0, 0, 0, time.Local)
+	ts := tm.String()
+	tu := tm.Unix()
+	td := tm.Format("2006-01-02")
 	mapper := NewMapper()
 	m := mapper.ObjectToMap(&Object{
 		Float: ObjectMarshalFloat{f: 66.66},
@@ -170,11 +188,15 @@ func TestMarshaller(t *testing.T) {
 			Float: ObjectMarshalFloat{f: 88.88}},
 		PointerNestFloat: &NestObject{
 			Float: ObjectMarshalFloat{f: 99.99}},
+		Map: ObjectMarshalMap{t: tm},
 	})
 	assertMap(t, m, map[string]interface{}{
-		"float":        66.66,
-		"nest_float":   88.88,
-		"p_nest_float": 99.99,
+		"float":           66.66,
+		"nest_float":      88.88,
+		"p_nest_float":    99.99,
+		"map_time_string": ts,
+		"map_time_unix":   tu,
+		"map_time_date":   td,
 	})
 }
 

--- a/kv/marshal_test.go
+++ b/kv/marshal_test.go
@@ -153,6 +153,7 @@ type ObjectMarshalMap struct {
 
 func (o ObjectMarshalMap) MapperMarshal() interface{} {
 	return map[string]interface{}{
+		"":            o.t.Format("2006-01-02 15:04:05"),
 		"time_string": o.t.String(),
 		"time_unix":   o.t.Unix(),
 		"time_date":   o.t.Format("2006-01-02"),
@@ -181,6 +182,7 @@ func TestMarshaller(t *testing.T) {
 	ts := tm.String()
 	tu := tm.Unix()
 	td := tm.Format("2006-01-02")
+	tt := tm.Format("2006-01-02 15:04:05")
 	mapper := NewMapper()
 	m := mapper.ObjectToMap(&Object{
 		Float: ObjectMarshalFloat{f: 66.66},
@@ -194,6 +196,7 @@ func TestMarshaller(t *testing.T) {
 		"float":           66.66,
 		"nest_float":      88.88,
 		"p_nest_float":    99.99,
+		"map":             tt,
 		"map_time_string": ts,
 		"map_time_unix":   tu,
 		"map_time_date":   td,

--- a/kv/marshal_test.go
+++ b/kv/marshal_test.go
@@ -159,18 +159,22 @@ func TestMarshaller(t *testing.T) {
 		Float ObjectMarshalFloat `kv:"float"`
 	}
 	type Object struct {
-		Float     ObjectMarshalFloat `kv:"float"`
-		NestFloat NestObject         `kv:"nest"`
+		Float            ObjectMarshalFloat `kv:"float"`
+		NestFloat        NestObject         `kv:"nest"`
+		PointerNestFloat *NestObject        `kv:"p_nest"`
 	}
 	mapper := NewMapper()
 	m := mapper.ObjectToMap(&Object{
 		Float: ObjectMarshalFloat{f: 66.66},
 		NestFloat: NestObject{
 			Float: ObjectMarshalFloat{f: 88.88}},
+		PointerNestFloat: &NestObject{
+			Float: ObjectMarshalFloat{f: 99.99}},
 	})
 	assertMap(t, m, map[string]interface{}{
-		"float":      66.66,
-		"nest_float": 88.88,
+		"float":        66.66,
+		"nest_float":   88.88,
+		"p_nest_float": 99.99,
 	})
 }
 

--- a/kv/marshal_test.go
+++ b/kv/marshal_test.go
@@ -146,38 +146,31 @@ func TestMarshalMap(t *testing.T) {
 	})
 }
 
-type ObjectMarshalInt struct {
-	N int                `kv:"n"`
-	F ObjectMarshalFloat `kv:"float"`
-}
-
 type ObjectMarshalFloat struct {
-	F float64 `kv:"f"`
+	f float64
 }
 
-func (this *ObjectMarshalFloat) MapperMarshal() interface{} {
-	return this.F
+func (o ObjectMarshalFloat) MapperMarshal() interface{} {
+	return o.f
 }
 
 func TestMarshaller(t *testing.T) {
+	type NestObject struct {
+		Float ObjectMarshalFloat `kv:"float"`
+	}
 	type Object struct {
-		Int ObjectMarshalInt `kv:"int"`
-		S   string           `kv:"s"`
+		Float     ObjectMarshalFloat `kv:"float"`
+		NestFloat NestObject         `kv:"nest"`
 	}
 	mapper := NewMapper()
 	m := mapper.ObjectToMap(&Object{
-		Int: ObjectMarshalInt{
-			N: 99,
-			F: ObjectMarshalFloat{
-				F: 66.66,
-			},
-		},
-		S: "88",
+		Float: ObjectMarshalFloat{f: 66.66},
+		NestFloat: NestObject{
+			Float: ObjectMarshalFloat{f: 88.88}},
 	})
 	assertMap(t, m, map[string]interface{}{
-		"s":           "88",
-		"int_n":       99,
-		"int_float_f": 66.66,
+		"float":      66.66,
+		"nest_float": 88.88,
 	})
 }
 


### PR DESCRIPTION
## Breaking Change
- [trigger package] replace handler param callback by queue.Buffer for receiving the elements batch pack by trigger.
## Bugs
- [kv package] fix marshal failed for time.Time, time.Duration type marshal as struct
## Features
- [kv package] add MapperMarshaller interface for custom defined data marshaller
## Enhance
- [base] OriginalError use recursion check.
- [base] Error() format adjust, use "\n" split each fields.
- [kv package] ObjectToStruct map type support empty key